### PR TITLE
Added onOneServer option to short run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,14 @@ Commands won't run whilst Laravel is in maintenance mode. If you would like to f
 $shortSchedule->command('artisan-command')->everySecond()->runInMaintenanceMode();
 ```
 
+### Running Tasks On One Server
+
+Limit commands to only run on one server at a time. 
+
+```php
+$shortSchedule->command('artisan-command')->everySecond()->onOneServer();
+```
+
 ## Events
 
 Executing any code when responding to these events is blocking. If your code takes a long time to execute, all short scheduled jobs will be delayed. We highly recommend to put any code you wish to execute in response to these events on a queue. 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     ],
     "require": {
         "php": "^7.4",
+        "illuminate/cache": "6.18|^7.0",
         "react/event-loop": "^1.1",
         "spatie/temporary-directory": "^1.2"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4",
-        "illuminate/cache": "6.18|^7.0",
+        "illuminate/cache": "^7.0",
         "react/event-loop": "^1.1",
         "spatie/temporary-directory": "^1.2"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -25,4 +25,7 @@
         <log type="coverage-text" target="build/coverage.txt"/>
         <log type="coverage-clover" target="build/logs/clover.xml"/>
     </logging>
+    <php>
+        <env name="CACHE_DRIVER" value="array"/>
+    </php>
 </phpunit>

--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -108,12 +108,12 @@ class PendingShortScheduleCommand
         return $this;
     }
 
-    public function getOnOneServer()
+    public function getOnOneServer(): bool
     {
         return $this->onOneServer;
     }
 
-    public function cacheName()
+    public function cacheName(): string
     {
         return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->frequencyInSeconds.$this->command);
     }

--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -17,6 +17,8 @@ class PendingShortScheduleCommand
 
     protected bool $allowOverlaps = true;
 
+    protected bool $onOneServer = false;
+
     protected bool $evenInMaintenanceMode = false;
 
     protected array $constraints = [];
@@ -71,6 +73,13 @@ class PendingShortScheduleCommand
         return ! $shouldNotRun;
     }
 
+    public function onOneServer(): self
+    {
+        $this->onOneServer = true;
+
+        return $this;
+    }
+
     public function between(string $startTime, string $endTime): self
     {
         $this->constraints[] = new BetweenConstraint($startTime, $endTime);
@@ -97,5 +106,15 @@ class PendingShortScheduleCommand
         $this->constraints[] = new WhenConstraint($closure);
 
         return $this;
+    }
+
+    public function getOnOneServer()
+    {
+        return $this->onOneServer;
+    }
+
+    public function cacheName()
+    {
+        return 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1($this->frequencyInSeconds.$this->command);
     }
 }

--- a/src/ShortScheduleCommand.php
+++ b/src/ShortScheduleCommand.php
@@ -57,14 +57,16 @@ class ShortScheduleCommand extends PendingShortScheduleCommand
 
     protected function processOnOneServer(): void
     {
-        if (Cache::missing($this->pendingShortScheduleCommand->cacheName())) {
-            Cache::add($this->pendingShortScheduleCommand->cacheName(), true, 60);
-
-            $this->processCommand();
-            $this->waitForProcessToFinish();
-
-            Cache::forget($this->pendingShortScheduleCommand->cacheName());
+        if (Cache::has($this->pendingShortScheduleCommand->cacheName())) {
+            return;
         }
+
+        Cache::add($this->pendingShortScheduleCommand->cacheName(), true, 60);
+
+        $this->processCommand();
+        $this->waitForProcessToFinish();
+
+        Cache::forget($this->pendingShortScheduleCommand->cacheName());
     }
 
     private function processCommand(): void

--- a/src/ShortScheduleCommand.php
+++ b/src/ShortScheduleCommand.php
@@ -3,6 +3,7 @@
 namespace Spatie\ShortSchedule;
 
 use Illuminate\Support\Facades\App;
+use Illuminate\Support\Facades\Cache;
 use Spatie\ShortSchedule\Events\ShortScheduledTaskStarted;
 use Spatie\ShortSchedule\Events\ShortScheduledTaskStarting;
 use Symfony\Component\Process\Process;
@@ -51,8 +52,28 @@ class ShortScheduleCommand extends PendingShortScheduleCommand
 
     public function run(): void
     {
+        $this->pendingShortScheduleCommand->getOnOneServer() ? $this->processOnOneServer() : $this->processCommand() ;
+    }
+
+    private function processOnOneServer()
+    {
+        if (Cache::missing($this->pendingShortScheduleCommand->cacheName())) {
+            Cache::add($this->pendingShortScheduleCommand->cacheName(), true, 60);
+
+            $this->processCommand();
+
+            while ($this->process->isRunning()) {
+                // waiting for process to finish before clearing the cache item
+            }
+
+            Cache::forget($this->pendingShortScheduleCommand->cacheName());
+        }
+    }
+
+    private function processCommand()
+    {
         $commandString = $this->pendingShortScheduleCommand->command;
-        $this->process = Process::fromShellCommandline($this->pendingShortScheduleCommand->command);
+        $this->process = Process::fromShellCommandline($commandString);
 
         event(new ShortScheduledTaskStarting($commandString, $this->process));
         $this->process->start();

--- a/tests/Feature/ShortScheduleTest.php
+++ b/tests/Feature/ShortScheduleTest.php
@@ -116,8 +116,11 @@ class ShortScheduleTest extends TestCase
     }
 
     /** @test **/
-    public function it_will_run_command_on_one_server()
+    public function do_not_run_if_already_running_on_another_server()
     {
+        $key = 'framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1('0.05'."echo 'called' >> '{$this->getTempFilePath()}'");
+        Cache::add($key, true, 60);
+
         TestKernel::registerShortScheduleCommand(
             fn (ShortSchedule $shortSchedule) => $shortSchedule
                 ->exec("echo 'called' >> '{$this->getTempFilePath()}'")
@@ -127,8 +130,6 @@ class ShortScheduleTest extends TestCase
 
         $this
             ->runShortScheduleForSeconds(0.14)
-            ->assertTempFileContains('called', 2);
-
-        $this->assertTrue(Cache::has('framework'.DIRECTORY_SEPARATOR.'schedule-'.sha1('0.05'."echo 'called' >> '{$this->getTempFilePath()}'")));
+            ->assertTempFileContains('called', 0);
     }
 }


### PR DESCRIPTION

This is to fore fill the Issue I previously created https://github.com/spatie/laravel-short-schedule/issues/6

Update README.md to include new method. 
Update composer.json to require illuminate/cache. 
Added onOneServer method and protected property to PendingShortScheduleCommand. 
Refactored the run command to run one private method depending on the onOneServer value. OneOneServer still calls the processCommand method that do not have the onOneServer property set. 
Add a test to ensure the cache item exists when onOneServer is true and run.

I am not sure if my test is the best way to ensure success. It should have the flag set in Cache if using the option.

I did a lot of debugging and testing in local and positive this works. It does for my needed use case. I did not want to leave logging in the code in order to test against so maybe you have a better way of testing this than I to assure yourself.