### PR TITLE
Issue 7 supervisor not running

### DIFF
--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -23,8 +23,6 @@ class PendingShortScheduleCommand
 
     protected array $constraints = [];
 
-    protected ?string $basePath = null;
-
     public function everySecond(float $frequencyInSeconds = 1): self
     {
         return $this->everySeconds($frequencyInSeconds);
@@ -40,7 +38,6 @@ class PendingShortScheduleCommand
     public function command(string $artisanCommand):self
     {
         $this->command = "php artisan {$artisanCommand}";
-        $this->basePath = base_path();
 
         return $this;
     }

--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -23,6 +23,8 @@ class PendingShortScheduleCommand
 
     protected array $constraints = [];
 
+    protected ?string $basePath = null;
+
     public function everySecond(float $frequencyInSeconds = 1): self
     {
         return $this->everySeconds($frequencyInSeconds);
@@ -38,6 +40,7 @@ class PendingShortScheduleCommand
     public function command(string $artisanCommand):self
     {
         $this->command = "php artisan {$artisanCommand}";
+        $this->basePath = base_path();
 
         return $this;
     }

--- a/src/ShortScheduleCommand.php
+++ b/src/ShortScheduleCommand.php
@@ -72,7 +72,7 @@ class ShortScheduleCommand extends PendingShortScheduleCommand
     private function processCommand(): void
     {
         $commandString = $this->pendingShortScheduleCommand->command;
-        $this->process = Process::fromShellCommandline($commandString);
+        $this->process = Process::fromShellCommandline($commandString, $this->pendingShortScheduleCommand->basePath);
 
         event(new ShortScheduledTaskStarting($commandString, $this->process));
         $this->process->start();

--- a/src/ShortScheduleCommand.php
+++ b/src/ShortScheduleCommand.php
@@ -72,7 +72,7 @@ class ShortScheduleCommand extends PendingShortScheduleCommand
     private function processCommand(): void
     {
         $commandString = $this->pendingShortScheduleCommand->command;
-        $this->process = Process::fromShellCommandline($commandString, $this->pendingShortScheduleCommand->basePath);
+        $this->process = Process::fromShellCommandline($commandString, base_path());
 
         event(new ShortScheduledTaskStarting($commandString, $this->process));
         $this->process->start();


### PR DESCRIPTION
This resolves the issue discussed here https://github.com/spatie/laravel-short-schedule/issues/7

When the command short-schedule:run is run on the command line the current working directory is known by the Symfony Process::fromshellCommandLine https://symfony.com/doc/current/components/process.html#using-features-from-the-os-shell
 
However when the command is run from supervisor the base_path() of laravel is not known.

The PR automatically sets the Laravel base_path for any short schedule that uses the command() method and leaves the value null for those that use the exec method