### PR TITLE
Remove sanmai/phpunit-legacy-adapter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,6 @@
         "mockery/mockery": "^1.3.3",
         "orchestra/testbench": "^5.0|^6.0",
         "phpunit/phpunit": "^9.0",
-        "sanmai/phpunit-legacy-adapter": "^8.2",
         "spatie/test-time": "^1.2",
         "vimeo/psalm": "^4.3"
     },


### PR DESCRIPTION
I'm humbled, but really it should not be required.