### PR TITLE
Mitigate memory leaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ php artisan short-schedule:run
 
 You should use a process monitor like [Supervisor](http://supervisord.org/index.html) to keep this task going at all times, and to automatically start it when your server boots. Whenever you change the schedule, you should restart this command.
 
-Sometimes operations can take much RAM, in this case set option `--lifetime` short schedule worker may help:
+Sometimes operations can take much RAM, in this case setting the lifetime of the short schedule worker may help:
 
 ```bash
 php artisan short-schedule:run --lifetime=60 // after 1 minute the worker will be terminated
 ```
-When setting the lifetime of the worker, the worker and all it's child processes will be terminated, so the RAM will be freed, then something like supervisor will bring it back 
+When lifetime of the worker is set, after specified amount of seconds the worker and all it's child processes will be terminated, so some of RAM will be freed, then supervisor(or something like that) will bring it back 
 ### Lumen
 
 Before you can run the `php artisan short-schedule:run` command in your Lumen project, you should make a copy of the `ShortScheduleRunCommand` into your `app/Commands` folder:

--- a/README.md
+++ b/README.md
@@ -64,7 +64,8 @@ Sometimes operations can take much RAM, in this case setting the lifetime (in se
 ```bash
 php artisan short-schedule:run --lifetime=60 // after 1 minute the worker will be terminated
 ```
-When lifetime of the worker is set, after specified amount of seconds the worker and all it's child processes will be terminated, so some of RAM will be freed, then supervisor(or something like that) will bring it back 
+When lifetime of the worker is set, after specified amount of seconds the worker and all it's child processes will be terminated, so some of RAM will be freed, then supervisor (or similar watcher) will bring it back.
+
 ### Lumen
 
 Before you can run the `php artisan short-schedule:run` command in your Lumen project, you should make a copy of the `ShortScheduleRunCommand` into your `app/Commands` folder:

--- a/README.md
+++ b/README.md
@@ -59,6 +59,12 @@ php artisan short-schedule:run
 
 You should use a process monitor like [Supervisor](http://supervisord.org/index.html) to keep this task going at all times, and to automatically start it when your server boots. Whenever you change the schedule, you should restart this command.
 
+Sometimes operations can take much RAM, in this case set option `--lifetime` short schedule worker may help:
+
+```bash
+php artisan short-schedule:run --lifetime=60 // after 1 minute the worker will be terminated
+```
+When setting the lifetime of the worker, the worker and all it's child processes will be terminated, so the RAM will be freed, then something like supervisor will bring it back 
 ### Lumen
 
 Before you can run the `php artisan short-schedule:run` command in your Lumen project, you should make a copy of the `ShortScheduleRunCommand` into your `app/Commands` folder:

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ php artisan short-schedule:run
 
 You should use a process monitor like [Supervisor](http://supervisord.org/index.html) to keep this task going at all times, and to automatically start it when your server boots. Whenever you change the schedule, you should restart this command.
 
-Sometimes operations can take much RAM, in this case setting the lifetime of the short schedule worker may help:
+Sometimes operations can take much RAM, in this case setting the lifetime (in seconds) of the short schedule worker may help:
 
 ```bash
 php artisan short-schedule:run --lifetime=60 // after 1 minute the worker will be terminated

--- a/README.md
+++ b/README.md
@@ -59,12 +59,15 @@ php artisan short-schedule:run
 
 You should use a process monitor like [Supervisor](http://supervisord.org/index.html) to keep this task going at all times, and to automatically start it when your server boots. Whenever you change the schedule, you should restart this command.
 
-Sometimes operations can take much RAM, in this case setting the lifetime (in seconds) of the short schedule worker may help:
+## Handle memory leaks
+
+To deal with commands that leak memory, you can set the lifetime in seconds of the short schedule worker:
 
 ```bash
 php artisan short-schedule:run --lifetime=60 // after 1 minute the worker will be terminated
 ```
-When lifetime of the worker is set, after specified amount of seconds the worker and all it's child processes will be terminated, so some of RAM will be freed, then supervisor (or similar watcher) will bring it back.
+
+After the given amount of seconds, the worker and all it's child processes will be terminated, freeing all memory. Then supervisor (or similar watcher) will bring it back.
 
 ### Lumen
 

--- a/src/Commands/ShortScheduleRunCommand.php
+++ b/src/Commands/ShortScheduleRunCommand.php
@@ -11,7 +11,7 @@ class ShortScheduleRunCommand extends Command
     protected $signature = 'short-schedule:run {--lifetime=}';
 
     protected $description = 'Run the short scheduled commands
-                              {--lifetime= : The life time of worker';
+                              {--lifetime= : The lifetime in seconds of worker';
 
     public function handle()
     {

--- a/src/Commands/ShortScheduleRunCommand.php
+++ b/src/Commands/ShortScheduleRunCommand.php
@@ -8,15 +8,15 @@ use Spatie\ShortSchedule\ShortSchedule;
 
 class ShortScheduleRunCommand extends Command
 {
-    protected $signature = 'short-schedule:run {--life-time=}';
+    protected $signature = 'short-schedule:run {--lifetime=}';
 
     protected $description = 'Run the short scheduled commands
-                              {--life-time= : The life time of worker';
+                              {--lifetime= : The life time of worker';
 
     public function handle()
     {
         $loop = Factory::create();
 
-        (new ShortSchedule($loop))->registerCommands()->run($this->option('life-time'));
+        (new ShortSchedule($loop))->registerCommands()->run($this->option('lifetime'));
     }
 }

--- a/src/Commands/ShortScheduleRunCommand.php
+++ b/src/Commands/ShortScheduleRunCommand.php
@@ -8,14 +8,15 @@ use Spatie\ShortSchedule\ShortSchedule;
 
 class ShortScheduleRunCommand extends Command
 {
-    protected $signature = 'short-schedule:run';
+    protected $signature = 'short-schedule:run {--life-time=}';
 
-    protected $description = 'Run the short scheduled commands';
+    protected $description = 'Run the short scheduled commands
+                              {--life-time= : The life time of worker';
 
     public function handle()
     {
         $loop = Factory::create();
 
-        (new ShortSchedule($loop))->registerCommands()->run();
+        (new ShortSchedule($loop))->registerCommands()->run($this->option('life-time'));
     }
 }

--- a/tests/Unit/RunConstraints/WhenConstraintTest.php
+++ b/tests/Unit/RunConstraints/WhenConstraintTest.php
@@ -2,7 +2,7 @@
 
 namespace Spatie\ShortSchedule\Tests\Unit\RunConstraints;
 
-use PhpCsFixer\Tests\TestCase;
+use Spatie\ShortSchedule\Tests\TestCase;
 use Spatie\ShortSchedule\RunConstraints\WhenConstraint;
 
 class WhenConstraintTest extends TestCase


### PR DESCRIPTION
*Closes issue [#17](https://github.com/spatie/laravel-short-schedule/issues/17)*

What has been done (and why)
A lifetime of short schedule's worker has been added to mitigate RAM leaks when running frequent processes every seconds with allowing overlapping.

**How does it work**
A new property `$lifetime` was added in `Spatie\ShortSchedule\ShortSchedule` class.
In `ShortSchedule` class in run method, after adding every scheduled task to loop it will check if the lifetime property is set and if it was, it will add event loop termination.
The default lifetime for production environment is 30 seconds
For dev mode there is not lifetime constraint, to make it possible to run `php artisan short-schedule:run` command in console without auto exiting, when developing and testing features locally.

**How to test**
1. Set 5 short scheduled tasks in `App\Console\Kernel.php` with frequency of 1 second, don't use `withoutOverlapping()` method.

2. When running in non production mode (APP_ENV=local in .env file), execute in console `php artisan short-schedule:run --lifetime=5`. After each task will be executed once, the worker will terminate itself and all memory will be dismissed at once.

3. When running in production mode (APP_ENV=production in .env file) configure supervisor to run  `php artisan short-schedule:run`. Then the worker will terminate itself each 5 seconds and supervisor will bring it back.

**Tests**
At the moment I do not know how to create autotests for this PR
