### PR TITLE
Using the PHP Version the scheduler is called with for artisan commands

### DIFF
--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -37,7 +37,7 @@ class PendingShortScheduleCommand
 
     public function command(string $artisanCommand):self
     {
-        $this->command = "php artisan {$artisanCommand}";
+        $this->command = PHP_BINARY . " artisan {$artisanCommand}";
 
         return $this;
     }


### PR DESCRIPTION
On our ispconfig3 hosting instance the default php binary is version 5.6 but the scheduler is called with 
`php8.0 artisan short-schedule:run`
Heavily inspired by https://github.com/spatie/laravel-short-schedule/pull/21, just implementing the usage of PHP_BINARY