### PR TITLE
PendingShortScheduleCommand::command method will attempt to resolve command name if class name was given

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ protected function shortSchedule(\Spatie\ShortSchedule\ShortSchedule $shortSched
     
     // this command will run every half a second
     $shortSchedule->command('another-artisan-command')->everySeconds(0.5);
+    
+    // this command will run every second and its signature will be retrieved from command automatically
+    $shortSchedule->command(\Spatie\ShortSchedule\Tests\Unit\TestCommand::class)->everySecond();
 }
 ```
 
@@ -89,6 +92,9 @@ protected function shortSchedule(\Spatie\ShortSchedule\ShortSchedule $shortSched
 {
     // this artisan command will run every second
     $shortSchedule->command('artisan-command')->everySecond();
+    
+    // this artisan command will run every second, its signature will be resolved from container
+    $shortSchedule->command(\Spatie\ShortSchedule\Tests\Unit\TestCommand::class)->everySecond();
 }
 ```
 

--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -3,6 +3,7 @@
 namespace Spatie\ShortSchedule;
 
 use Closure;
+use Illuminate\Container\Container;
 use Illuminate\Support\Arr;
 use Spatie\ShortSchedule\RunConstraints\BetweenConstraint;
 use Spatie\ShortSchedule\RunConstraints\EnvironmentConstraint;
@@ -35,8 +36,12 @@ class PendingShortScheduleCommand
         return $this;
     }
 
-    public function command(string $artisanCommand):self
+    public function command(string $artisanCommand): self
     {
+        if (class_exists($artisanCommand)) {
+            $artisanCommand = Container::getInstance()->make($artisanCommand)->getName();
+        }
+
         $this->command = PHP_BINARY . " artisan {$artisanCommand}";
 
         return $this;

--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -39,7 +39,7 @@ class PendingShortScheduleCommand
     public function command(string $artisanCommand): self
     {
         if (class_exists($artisanCommand)) {
-            $artisanCommand = Container::getInstance()->make($artisanCommand)->getName();
+            $artisanCommand = app($artisanCommand)->getName();
         }
 
         $this->command = PHP_BINARY . " artisan {$artisanCommand}";

--- a/tests/Unit/PendingShortScheduleCommandTest.php
+++ b/tests/Unit/PendingShortScheduleCommandTest.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace Spatie\ShortSchedule\Tests\Unit;
+
+use Illuminate\Console\Command;
+use Orchestra\Testbench\TestCase as Orchestra;
+use ReflectionClass;
+use Spatie\ShortSchedule\PendingShortScheduleCommand;
+
+class PendingShortScheduleCommandTest extends Orchestra
+{
+    /** @test */
+    public function it_will_generate_command_from_command_class(): void
+    {
+        $pendingCommand = new PendingShortScheduleCommand();
+        $pendingCommand->command(TestCommand::class);
+        $reflectionClass = new ReflectionClass($pendingCommand);
+
+        $commandProperty = $reflectionClass->getProperty('command');
+        $commandProperty->setAccessible(true);
+
+        $artisanCommand = 'test-command';
+        $this->assertEquals(PHP_BINARY . " artisan {$artisanCommand}", $commandProperty->getValue($pendingCommand));
+    }
+}
+
+class TestCommand extends Command
+{
+    protected $signature = 'test-command';
+
+    public function handle(): void
+    {
+    }
+}


### PR DESCRIPTION
I noticed difference between original scheduler and shortScheduler that if I pass class name instead of actual artisan command signature, it does not attempt to resolve command name like in original Laravel scheduler (\Illuminate\Console\Scheduling\Schedule::command). So I thought to add such functionality to make it more convenient for for everyone when moving from regular schedule to short schedule.