### PR TITLE
Replacing call to EventLoop\Factory with call to EventLoop\Loop. Ensuring value of lifetime option is either int of null as required

### DIFF
--- a/src/Commands/ShortScheduleRunCommand.php
+++ b/src/Commands/ShortScheduleRunCommand.php
@@ -3,7 +3,7 @@
 namespace Spatie\ShortSchedule\Commands;
 
 use Illuminate\Console\Command;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 use Spatie\ShortSchedule\ShortSchedule;
 
 class ShortScheduleRunCommand extends Command
@@ -14,8 +14,13 @@ class ShortScheduleRunCommand extends Command
 
     public function handle()
     {
-        $loop = Factory::create();
+        $loop = Loop::get();
 
-        (new ShortSchedule($loop))->registerCommands()->run($this->option('lifetime'));
+        $lifetime = $this->option('lifetime');
+        if ($lifetime !== null) {
+            $lifetime = (int)$lifetime;
+        }
+
+        (new ShortSchedule($loop))->registerCommands()->run($lifetime);
     }
 }


### PR DESCRIPTION
This PR contains two small changes to `src/Commands/ShortScheduleRunCommand.php`

1.
Replacing call to React\EventLoop\Factory with call to React\EventLoop\Loop, since Factory is deprecated and suggests usage of Loop. 

2.
The run method called requires the `$lifetime` argument to be of type int or null, however this isn't ensured as it could be also string for example. This PR also solves this and ensures that the value passed to the run method is either int or null. This is an issue for people who use this library with Lumen, which requires them to copy the Command to their repository ([Docs for usage with Lumen](https://github.com/spatie/laravel-short-schedule#lumen)). However, static code analyzers, like PHPStan, will notice that the type passed to run is not guaranteed to be int|null, and will therefore trigger and error.

Solves:
- https://github.com/spatie/laravel-short-schedule/issues/38
- https://github.com/spatie/laravel-short-schedule/discussions/39