### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,13 +163,13 @@ $shortSchedule->command('artisan-command')->when(fn() => rand() %2)->everySecond
  The command will only run on the given environment.
  
  ```php
- $shortSchedule->command('artisan-command')->environment('production')->everySecond();
+ $shortSchedule->command('artisan-command')->environments('production')->everySecond();
  ```
 
 You can also pass an array:
 
  ```php
- $shortSchedule->command('artisan-command')->environment(['staging', 'production'])->everySecond();
+ $shortSchedule->command('artisan-command')->environments(['staging', 'production'])->everySecond();
  ```
 
 ### Composite constraints


### PR DESCRIPTION
This PR fixes a documentation typo related to the `environments` method.