### PR TITLE
Fix: Take spaces into consideration in php binary path

### DIFF
--- a/src/PendingShortScheduleCommand.php
+++ b/src/PendingShortScheduleCommand.php
@@ -41,7 +41,7 @@ class PendingShortScheduleCommand
             $artisanCommand = app($artisanCommand)->getName();
         }
 
-        $this->command = PHP_BINARY . " artisan {$artisanCommand}";
+        $this->command = '"' . PHP_BINARY . "\" artisan {$artisanCommand}";
 
         return $this;
     }

--- a/tests/Unit/PendingShortScheduleCommandTest.php
+++ b/tests/Unit/PendingShortScheduleCommandTest.php
@@ -20,7 +20,8 @@ class PendingShortScheduleCommandTest extends Orchestra
         $commandProperty->setAccessible(true);
 
         $artisanCommand = 'test-command';
-        $this->assertEquals(PHP_BINARY . " artisan {$artisanCommand}", $commandProperty->getValue($pendingCommand));
+
+        $this->assertEquals('"' . PHP_BINARY . "\" artisan {$artisanCommand}", $commandProperty->getValue($pendingCommand));
     }
 }
 


### PR DESCRIPTION
This pull request updates the command generation logic to properly handle PHP binary paths that may contain spaces. 
By wrapping the PHP binary path in quotes, the command will execute correctly even if the path includes spaces. 
The related test has also been updated to reflect this change.

Tested this under Linux & Mac envs, but I am pretty sure wrapping stuff in quotes is a valid syntax for Windows as well when the given path contains spaces.