### PR TITLE
Fix typo in scheduling documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ After the given amount of seconds, the worker and all it's child processes will 
 
 ## Usage
 
-Un your routes/console.php file, you can use the `ShortSchedule` facade to schedule commands.
+In your routes/console.php file, you can use the `ShortSchedule` facade to schedule commands.
 
 ```php
 // in your routes/console.php file


### PR DESCRIPTION
## Summary

This PR fixes a small typo in the documentation.

### Changes

Updated:

```
Un your routes/console.php file, you can use the `ShortSchedule` facade to schedule commands.
````

to:

```
In your routes/console.php file, you can use the `ShortSchedule` facade to schedule commands.
```

## Type of Change

* [x] Documentation update
* [ ] Bug fix
* [ ] New feature
* [ ] Breaking change

No functional changes were made.